### PR TITLE
Parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: csharp
 solution: ceilidh-core.sln
 mono: none
 dotnet: 2.1.302
+os:
+  - linux
+  - osx
 install:
   - dotnet restore
 script:

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -14,8 +14,9 @@
 
 ## Advanced Usage
 
+* To improve application startup time, use `CobbleContext.ExecuteAsync` instead of `CobbleContext.Execute`. This will cause initialization steps to be performed in parallel where possible, saving a lot of time if any of your constructors are long-running.
 * If any class you register with the system implements `ILateInject<>` at least once, the constructed instance will be notified whenever any new classes are registered with the owner `CobbleContext` after `CobbleContext.Execute` is called.
   * This allows for, in certain conditions, plugins to be loaded without requiring an application restart.
 * `CobbleContext.AddManaged` can accept any implementation of `IInstanceGenerator`, not just existing types. This can allow for object construction that does not use a type constructor.
   * See the [reference implementations](ProjectCeilidh.Cobble/Generator) of `IInstanceGenerator` for examples on how to implement this interface.
-* Creating a `CobbleContext` automatically registers itself with the dependency injection system, allowing you to depend on it and access it later on.
+* The `CobbleContext` you create automatically registers itself with the dependency injection system, allowing you to depend on it and access it later on.

--- a/ProjectCeilidh.Cobble.Tests/ProjectCeilidh.Cobble.Tests.csproj
+++ b/ProjectCeilidh.Cobble.Tests/ProjectCeilidh.Cobble.Tests.csproj
@@ -4,12 +4,17 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <StartupObject></StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectCeilidh.Cobble/Data/DirectedGraph.cs
+++ b/ProjectCeilidh.Cobble/Data/DirectedGraph.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ProjectCeilidh.Cobble.Data
 {
@@ -10,6 +12,7 @@ namespace ProjectCeilidh.Cobble.Data
     /// <typeparam name="TNode"></typeparam>
     internal class DirectedGraph<TNode>
     {
+        private readonly HashSet<TNode> _initialNodes;
         private readonly Dictionary<TNode, int> _nodes;
         private readonly Dictionary<TNode, HashSet<TNode>> _outgoingEdges;
 
@@ -18,7 +21,6 @@ namespace ProjectCeilidh.Cobble.Data
         /// </summary>
         public DirectedGraph() : this(Enumerable.Empty<TNode>())
         {
-
         }
 
         /// <summary>
@@ -27,7 +29,8 @@ namespace ProjectCeilidh.Cobble.Data
         /// <param name="initialNodes">Initial nodes.</param>
         public DirectedGraph(IEnumerable<TNode> initialNodes)
         {
-            _nodes = initialNodes.ToDictionary(x => x, x => 0);
+            _initialNodes = new HashSet<TNode>(initialNodes);
+            _nodes = _initialNodes.ToDictionary(x => x, x => 0);
             _outgoingEdges = new Dictionary<TNode, HashSet<TNode>>();
         }
 
@@ -36,7 +39,11 @@ namespace ProjectCeilidh.Cobble.Data
         /// </summary>
         /// <returns>True if the node was added, false otherwise.</returns>
         /// <param name="node">The node to add.</param>
-        public void Add(TNode node) => _nodes[node] = 0;
+        public void Add(TNode node)
+        {
+            _nodes[node] = 0;
+            _initialNodes.Add(node);
+        }
 
         /// <summary>
         /// Add a link from <paramref name="src"/> to <paramref name="dst"/>.
@@ -50,6 +57,7 @@ namespace ProjectCeilidh.Cobble.Data
 
             outSet.Add(dst);
             _nodes[dst]++;
+            _initialNodes.Remove(dst);
         }
 
         /// <summary>
@@ -64,7 +72,7 @@ namespace ProjectCeilidh.Cobble.Data
         {
             var refDict = new Dictionary<TNode, int>(_nodes);
 
-            var list = new LinkedList<TNode>(refDict.Where(x => x.Value == 0).Select(x => x.Key));
+            var list = new LinkedList<TNode>(_initialNodes);
 
             while (list.Count > 0)
             {
@@ -86,32 +94,34 @@ namespace ProjectCeilidh.Cobble.Data
                 throw new CyclicGraphException(remaining.Select(x => x.Key));
         }
 
-        public IEnumerable<TNode[]> ParallelTopologicalSort()
+        /// <summary>
+        /// Topologically sort the graph, invoking the callback in parallel where possible
+        /// </summary>
+        /// <param name="callback">The callback to invoke</param>
+        /// <returns>A task following the parallel sort</returns>
+        public async Task ParallelTopologicalSort(Action<TNode> callback)
         {
-            var refDict = new Dictionary<TNode, int>(_nodes);
+            var refDict = new ConcurrentDictionary<TNode, int>(_nodes);
 
-            var list = new LinkedList<TNode>(refDict.Where(x => x.Value == 0).Select(x => x.Key));
+            await Task.WhenAll(_initialNodes.Select(HandleItem));
 
-            while (list.Count > 0)
-            {
-                var arr = new TNode[list.Count];
-                list.CopyTo(arr, 0);
-                list.Clear();
-
-                yield return arr;
-
-                foreach (var node in arr)
-                foreach (var target in _outgoingEdges.TryGetValue(node, out var set) ? set : Enumerable.Empty<TNode>())
-                {
-                    var con = --refDict[target];
-                    if (con == 0) list.AddLast(target);
-                }
-            }
-
-            var remaining = refDict.Where(x => x.Value > 0).ToList();
+            var remaining = refDict.Where(x => x.Value != 0).ToList();
 
             if (remaining.Count > 0)
                 throw new CyclicGraphException(remaining.Select(x => x.Key));
+
+            async Task HandleItem(TNode node)
+            {
+                await Task.Run(() => callback(node));
+
+                if (_outgoingEdges.TryGetValue(node, out var set))
+                    await Task.WhenAll(set.Select(async target =>
+                    {
+                        var con = refDict.AddOrUpdate(target, 0, (a, b) => b - 1);
+
+                        if (con == 0) await HandleItem(target);
+                    }));
+            }
         }
 
         public class CyclicGraphException : Exception

--- a/ProjectCeilidh.Cobble/Extensions.cs
+++ b/ProjectCeilidh.Cobble/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ProjectCeilidh.Cobble
 {

--- a/ProjectCeilidh.Cobble/Generator/BareLateInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/BareLateInstanceGenerator.cs
@@ -26,5 +26,7 @@ namespace ProjectCeilidh.Cobble.Generator
         }
 
         public object GenerateInstance(object[] args) => _instance;
+
+        public override string ToString() => $"BareLateInstanceGenerator({_instance.GetType().FullName})";
     }
 }

--- a/ProjectCeilidh.Cobble/Generator/DictionaryInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/DictionaryInstanceGenerator.cs
@@ -43,6 +43,8 @@ namespace ProjectCeilidh.Cobble.Generator
             return proxy;
         }
 
+        public override string ToString() => $"DictionaryInstanceGenerator({_contractType.FullName})";
+
         /// <summary>
         /// Provides a way to implement the specified contract at runtime.
         /// </summary>

--- a/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
@@ -29,5 +29,7 @@ namespace ProjectCeilidh.Cobble.Generator
             var ctor = _target.GetConstructors().Single();
             return ctor.Invoke(args);
         }
+
+        public override string ToString() => $"TypeLateInstanceGenerator({_target.FullName})";
     }
 }

--- a/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
+++ b/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/Ceilidh-Team/Cobble.git</RepositoryUrl>
     <Copyright>2018 Olivia Trewin</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.1" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Cobble is a [.NET Standard](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) library for building extensible applications through bespoke dependency injection.
 
 * Cross-platform: Because it uses .NET Standard, Cobble will work with any modern implementation of .NET.
-* Lightweight: Cobble uses high-performance algorithms to execute quickly, and any overhead is only incurred one time.
+* Lightweight: Cobble uses high-performance parallel algorithms to execute quickly, and any overhead is only incurred one time.
 * Learn Once, Write Anywhere: Cobble makes no assumptions about the function of your program or the technology you use, making it easy to use for any task.
 
 [Learn how to get started with Cobble](GettingStarted.md)


### PR DESCRIPTION
* Changed the signature of `DirectedGraph.ParallelTopologicalSort`
* `ExecuteAsync` can now resolve partial subtrees in parallel, improving the perfomance dramatically when there are long-running initialization sequences in a far-off corner of the dependency graph