### PR TITLE
Dispose and version

### DIFF
--- a/ProjectCeilidh.Cobble.Tests/AsyncCobbleContextTests.cs
+++ b/ProjectCeilidh.Cobble.Tests/AsyncCobbleContextTests.cs
@@ -108,6 +108,32 @@ namespace ProjectCeilidh.Cobble.Tests
                 Assert.Equal("Hi", testUnit.TestValue);
         }
 
+        [Fact]
+        public async Task DisposeTest()
+        {
+            _context.AddManaged<DisposeTestUnit>();
+
+            await _context.ExecuteAsync();
+            Assert.True(_context.TryGetSingleton(out DisposeTestUnit testUnit) && !testUnit.IsDisposed);
+            _context.Dispose();
+            Assert.True(testUnit.IsDisposed);
+        }
+
+        private class DisposeTestUnit : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public DisposeTestUnit()
+            {
+                IsDisposed = false;
+            }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
+        }
+
         private interface ITestUnit
         {
             string TestValue { get; }

--- a/ProjectCeilidh.Cobble.Tests/CobbleContextTests.cs
+++ b/ProjectCeilidh.Cobble.Tests/CobbleContextTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace ProjectCeilidh.Cobble.Tests
 {
-    public class CobbleContextTests
+    public class CobbleContextTests : IDisposable
     {
         private readonly CobbleContext _context;
 
@@ -107,6 +107,32 @@ namespace ProjectCeilidh.Cobble.Tests
                 Assert.Equal("Hi", testUnit.TestValue);
         }
 
+        [Fact]
+        public void DisposeTest()
+        {
+            _context.AddManaged<DisposeTestUnit>();
+
+            _context.Execute();
+            Assert.True(_context.TryGetSingleton(out DisposeTestUnit testUnit) && !testUnit.IsDisposed);
+            _context.Dispose();
+            Assert.True(testUnit.IsDisposed);
+        }
+
+        private class DisposeTestUnit : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public DisposeTestUnit()
+            {
+                IsDisposed = false;
+            }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
+        }
+
         private interface ITestUnit
         {
             string TestValue { get; }
@@ -150,6 +176,11 @@ namespace ProjectCeilidh.Cobble.Tests
             {
                 TestUnits.Add(unit);
             }
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
         }
     }
 }

--- a/ProjectCeilidh.Cobble/Extensions.cs
+++ b/ProjectCeilidh.Cobble/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace ProjectCeilidh.Cobble
 {
@@ -36,16 +37,16 @@ namespace ProjectCeilidh.Cobble
 
         public static IEnumerable<Type> GetAssignableFrom(this Type type)
         {
-            foreach (var intf in type.GetInterfaces())
+            foreach (var intf in type.GetTypeInfo().ImplementedInterfaces)
                 yield return intf;
 
             yield return type;
 
-            var b = type.BaseType;
+            var b = type.GetTypeInfo().BaseType;
 
             while (b != null && b != typeof(object))
             {
-                b = b.BaseType;
+                b = b.GetTypeInfo().BaseType;
                 yield return b;
             }
         }

--- a/ProjectCeilidh.Cobble/Generator/BareLateInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/BareLateInstanceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace ProjectCeilidh.Cobble.Generator
 {
@@ -21,7 +22,7 @@ namespace ProjectCeilidh.Cobble.Generator
             _instance = instance ?? throw new ArgumentNullException(nameof(instance));
 
             var type = _instance.GetType();
-            LateDependencies = type.GetInterfaces().Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ILateInject<>)).Select(x => x.GetGenericArguments()[0]).ToArray();
+            LateDependencies = type.GetTypeInfo().ImplementedInterfaces.Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ILateInject<>)).Select(x => x.GenericTypeArguments[0]).ToArray();
             Provides = type.GetAssignableFrom().ToArray();
         }
 

--- a/ProjectCeilidh.Cobble/Generator/DictionaryInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/DictionaryInstanceGenerator.cs
@@ -11,7 +11,7 @@ namespace ProjectCeilidh.Cobble.Generator
     /// </summary>
     public class DictionaryInstanceGenerator : IInstanceGenerator
     {
-        private static readonly MethodInfo DispatchProxyCreate = typeof(DispatchProxy).GetMethod(nameof(DispatchProxy.Create)) ?? throw new Exception("Cannot find DispatchProxy.Create - this should be impossible.");
+        private static readonly MethodInfo DispatchProxyCreate = typeof(DispatchProxy).GetRuntimeMethod(nameof(DispatchProxy.Create), new Type[0]) ?? throw new Exception("Cannot find DispatchProxy.Create - this should be impossible.");
 
         public IEnumerable<Type> Provides { get; }
         public IEnumerable<Type> Dependencies { get; }
@@ -28,8 +28,8 @@ namespace ProjectCeilidh.Cobble.Generator
         /// <param name="implementations">A dictionary containing all implemented functions as delegates.</param>
         public DictionaryInstanceGenerator(Type contractType, Delegate ctor, IReadOnlyDictionary<MethodInfo, Delegate> implementations)
         {
-            Dependencies = ctor == null ? new Type[0] : ctor.Method.GetParameters().Select(x => x.ParameterType).ToArray();
-            Provides = contractType.GetInterfaces().Concat(new []{ contractType }).Concat(contractType.Unroll(x => x.BaseType == typeof(object) || x.BaseType == null ? new Type[0] : new []{ x.BaseType }));
+            Dependencies = ctor == null ? new Type[0] : ctor.GetMethodInfo().GetParameters().Select(x => x.ParameterType).ToArray();
+            Provides = contractType.GetTypeInfo().ImplementedInterfaces.Concat(new []{ contractType }).Concat(contractType.Unroll(x => x.GetTypeInfo().BaseType == typeof(object) || x.GetTypeInfo().BaseType == null ? new Type[0] : new []{ x.GetTypeInfo().BaseType }));
             _contractType = contractType;
             _ctor = ctor;
             _implementations = implementations;

--- a/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace ProjectCeilidh.Cobble.Generator
 {
@@ -19,14 +20,14 @@ namespace ProjectCeilidh.Cobble.Generator
         public TypeLateInstanceGenerator(Type target)
         {
             _target = target;
-            Dependencies = target.GetConstructors().Single().GetParameters().Select(x => x.ParameterType).ToArray();
+            Dependencies = target.GetTypeInfo().DeclaredConstructors.Single().GetParameters().Select(x => x.ParameterType).ToArray();
             Provides = target.GetAssignableFrom().ToArray();
-            LateDependencies = target.GetInterfaces().Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ILateInject<>)).Select(x => x.GetGenericArguments()[0]).ToArray();
+            LateDependencies = target.GetTypeInfo().ImplementedInterfaces.Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ILateInject<>)).Select(x => x.GenericTypeArguments[0]).ToArray();
         }
 
         public object GenerateInstance(object[] args)
         {
-            var ctor = _target.GetConstructors().Single();
+            var ctor = _target.GetTypeInfo().DeclaredConstructors.Single();
             return ctor.Invoke(args);
         }
 

--- a/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
+++ b/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Olivia Trewin</Authors>
     <Company>Project Ceilidh</Company>
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/Ceilidh-Team/Cobble.git</RepositoryUrl>
     <Copyright>2018 Olivia Trewin</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.1" />


### PR DESCRIPTION
Changed CobbleContext to allow being disposed, which allows units to implement dispose if they need to be destroyed at some point
Reduced the .NET Standard version to improve compatibility