### PR TITLE
Recursive dispose

### DIFF
--- a/ProjectCeilidh.Cobble/CobbleContext.cs
+++ b/ProjectCeilidh.Cobble/CobbleContext.cs
@@ -98,7 +98,7 @@ namespace ProjectCeilidh.Cobble
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            if (type.GetTypeInfo().DeclaredConstructors.Count(x => (x.CallingConvention & CallingConventions.HasThis) != 0) != 1)
+            if (type.GetTypeInfo().DeclaredConstructors.Count(x => x.IsPublic && (x.CallingConvention & CallingConventions.HasThis) != 0) != 1)
                 throw new ArgumentException("Managed types must have exactly one public constructor.", nameof(type));
 
             AddManaged(new TypeLateInstanceGenerator(type));
@@ -254,7 +254,7 @@ namespace ProjectCeilidh.Cobble
                     return b;
                 });
 
-            if (instance is IDisposable disp)
+            if (!ReferenceEquals(instance, this) && instance is IDisposable disp)
                 _disposeHooks.Add(disp);
                 
         }

--- a/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
+++ b/ProjectCeilidh.Cobble/Generator/TypeLateInstanceGenerator.cs
@@ -20,14 +20,14 @@ namespace ProjectCeilidh.Cobble.Generator
         public TypeLateInstanceGenerator(Type target)
         {
             _target = target;
-            Dependencies = target.GetTypeInfo().DeclaredConstructors.Single(x => (x.CallingConvention & CallingConventions.HasThis) != 0).GetParameters().Select(x => x.ParameterType).ToArray();
+            Dependencies = target.GetTypeInfo().DeclaredConstructors.Single(x => x.IsPublic && (x.CallingConvention & CallingConventions.HasThis) != 0).GetParameters().Select(x => x.ParameterType).ToArray();
             Provides = target.GetAssignableFrom().ToArray();
             LateDependencies = target.GetTypeInfo().ImplementedInterfaces.Where(x => x.IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ILateInject<>)).Select(x => x.GenericTypeArguments[0]).ToArray();
         }
 
         public object GenerateInstance(object[] args)
         {
-            var ctor = _target.GetTypeInfo().DeclaredConstructors.Single(x => (x.CallingConvention & CallingConventions.HasThis) != 0);
+            var ctor = _target.GetTypeInfo().DeclaredConstructors.Single(x => x.IsPublic && (x.CallingConvention & CallingConventions.HasThis) != 0);
             return ctor.Invoke(args);
         }
 

--- a/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
+++ b/ProjectCeilidh.Cobble/ProjectCeilidh.Cobble.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/Ceilidh-Team/Cobble.git</RepositoryUrl>
     <Copyright>2018 Olivia Trewin</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.1" />


### PR DESCRIPTION
* Fixed a bug where a `CobbleContext` would dispose itself (because it's part of the normal dependency graph) and dispose some objects twice
* Made the constructor detection ignore non-public constructors